### PR TITLE
Allow caller to specify NSURLSession

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -74,7 +74,7 @@
     [[OCSPAuthURLSessionDelegate alloc] initWithLogger:logger
                                              ocspCache:ocspCache
                                          modifyOCSPURL:modifyOCSPURL
-                                         sessionConfig:nil];
+                                               session:nil];
 
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
 
@@ -178,7 +178,7 @@
     [ocspCache lookup:trust
            andTimeout:10
         modifyOCSPURL:nil
-        sessionConfig:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+              session:nil
            completion:^(OCSPCacheLookupResult * _Nonnull result) {
         [self checkResultAndEvaluate:trust
                                 cert:cert
@@ -266,7 +266,7 @@
                withIssuer:issuer
                andTimeout:10
             modifyOCSPURL:nil
-            sessionConfig:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+                  session:nil
                completion:
          ^(OCSPCacheLookupResult *result) {
              XCTAssert(result != nil);
@@ -327,7 +327,7 @@
            withIssuer:issuer
            andTimeout:defaultTimeout
         modifyOCSPURL:nil
-        sessionConfig:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+              session:nil
            completion:
      ^(OCSPCacheLookupResult *r) {
          XCTAssert(r.response == nil);
@@ -389,7 +389,7 @@
            withIssuer:issuer
            andTimeout:defaultTimeout
         modifyOCSPURL:nil
-        sessionConfig:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+              session:nil
            completion:
      ^(OCSPCacheLookupResult *r) {
          XCTAssert(r.response == nil);
@@ -408,7 +408,7 @@
     }];
 }
 
-#pragma mark - Helpers
+#pragma mark - Helpers for certificate evaluations
 
 // Run a series of tests against the cache
 - (void)ocspCacheTestWithCert:(SecCertificateRef)certRef andIssuer:(SecCertificateRef)issuerRef
@@ -538,9 +538,9 @@
     [cache lookup:certRef
        withIssuer:issuerRef
        andTimeout:timeout
-     modifyOCSPURL:nil
-     sessionConfig:[NSURLSessionConfiguration ephemeralSessionConfiguration]
-        completion:
+    modifyOCSPURL:nil
+          session:nil
+       completion:
      ^(OCSPCacheLookupResult * _Nonnull result) {
 
          [self checkResultAndEvaluate:trust
@@ -629,6 +629,8 @@
 
     return trustEvaulateResult;
 }
+
+#pragma mark - Helpers for loading certificates
 
 // Load certificate and check that common name matches
 - (Error*)loadCertificate:(NSString*)filePath

--- a/OCSPCache/Classes/OCSPAuthURLSessionDelegate.h
+++ b/OCSPCache/Classes/OCSPAuthURLSessionDelegate.h
@@ -51,18 +51,19 @@ typedef void (^AuthCompletion)(NSURLSessionAuthChallengeDisposition, NSURLCreden
 @interface OCSPAuthURLSessionDelegate : NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate>
 
 /// Initialize OCSPAuthURLSessionDelegate.
-/// @param logger logger Logger for emitting diagnostic information. Logging should only be used for testing since it emits the URLs
-/// corresponding to the certificate being validated.
+/// @param logger logger Logger for emitting diagnostic information. Logging should only be used for
+/// testing since it emits the URLs corresponding to the certificate being validated.
 /// @param ocspCache OCSPCache to use for making OCSP requests and caching OCSP responses.
 /// @param modifyOCSPURL Block which updates each OCSP URL. This is an opportunity for the caller to:
 /// update the URL to point through a local proxy, whitelist the URL if needed, etc. If the provided
 /// block returns nil, the original URL is used.
-/// @param sessionConfig Session configuration with which to perform OCSP requests. This is an opportunity for the caller to
-/// specify a proxy to be used by the OCSP requests. If nil, `defaultSessionConfiguration` is used.
+/// @param session Session with which to perform OCSP requests. This is an opportunity for the
+/// caller to specify a proxy to be used by the OCSP requests. If nil, a session with
+/// `ephemeralSessionConfiguration` is created and used.
 -  (instancetype)initWithLogger:(void (^)(NSString*))logger
                       ocspCache:(OCSPCache*)ocspCache
                   modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
-                  sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig;
+                        session:(NSURLSession*__nullable)session;
 
 /// Evaluate trust object performing certificate revocation checks in the following order:
 ///   1. OCSP staple
@@ -89,13 +90,13 @@ typedef void (^AuthCompletion)(NSURLSessionAuthChallengeDisposition, NSURLCreden
 /// of its issuer.
 /// @param modifyOCSPURLOverride Override the block specified when OCSPAuthURLSessionDelegate was initialized. This allows
 /// independent tasks to manage their own URL rewriting while sharing the same underlying OCSPAuthURLSessionDelegate.
-/// @param sessionConfigOverride Override the session configuration specified when OCSPAuthURLSessionDelegate was
-/// initialized. This allows independent tasks to mange the NSURLSessionConfiguration used per trust evaluation.
+/// @param sessionOverride Override the session specified when OCSPAuthURLSessionDelegate was
+/// initialized. This allows independent tasks to mange the NSURLSession used per trust evaluation.
 /// @param completionHandler Completion handler from the NSURLSessionDelegate or NSURLSessionTaskDelegate
 /// authentication challenge.
 - (BOOL)evaluateTrust:(SecTrustRef)trust
 modifyOCSPURLOverride:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURLOverride
-sessionConfigOverride:(NSURLSessionConfiguration*__nullable)sessionConfigOverride
+      sessionOverride:(NSURLSession*__nullable)sessionOverride
     completionHandler:(AuthCompletion)completionHandler;
 
 /// NSURLSessionDelegate implementation

--- a/OCSPCache/Classes/OCSPCache.h
+++ b/OCSPCache/Classes/OCSPCache.h
@@ -145,22 +145,23 @@ typedef NS_ERROR_ENUM(OCSPCacheErrorDomain, OCSPCacheErrorCode) {
  @param modifyOCSPURL Block which updates each OCSP URL. This is an opportunity for the caller to:
  update the URL to point through a local proxy, whitelist the URL if needed, etc. If the provided
  block returns nil, the original URL is used.
- @param sessionConfig Session configuration with which to perform OCSP requests. This is an opportunity for the caller to
- specify a proxy to be used by the OCSP requests. If nil, `defaultSessionConfiguration` is used.
+ @param session Session with which to perform OCSP requests. This is an opportunity for the caller
+ to specify a proxy to be used by the OCSP requests. If nil, a session with
+ `ephemeralSessionConfiguration` is created and used.
  @param completion Completion handler which is called when the lookup completes. If result.err is
  set then the other values should be ignored.
  */
 - (void)lookup:(SecTrustRef)secTrustRef
     andTimeout:(NSTimeInterval)timeout
  modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
- sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+       session:(NSURLSession*__nullable)session
     completion:(void (^)(OCSPCacheLookupResult *result))completion;
 
 /// Blocking lookup
 - (OCSPCacheLookupResult*)lookup:(SecTrustRef)secTrustRef
                       andTimeout:(NSTimeInterval)timeout
                    modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
-                   sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig;
+                         session:(NSURLSession*__nullable)session;
 
 /*!
  Obtain an OCSP response for the provided certificate.
@@ -180,8 +181,9 @@ typedef NS_ERROR_ENUM(OCSPCacheErrorDomain, OCSPCacheErrorCode) {
  @param modifyOCSPURL Block which updates each OCSP URL. This is an opportunity for the caller to:
  update the URL to point through a local proxy, whitelist the URL if needed, etc. If the provided
  block returns nil, the original URL is used.
- @param sessionConfig Session configuration with which to perform OCSP requests. This is an opportunity for the caller to
- specify a proxy to be used by the OCSP requests. If nil, `defaultSessionConfiguration` is used.
+ @param session Session with which to perform OCSP requests. This is an opportunity for the caller
+ to specify a proxy to be used by the OCSP requests.  If nil, a session with
+ `ephemeralSessionConfiguration` is created and used.
  @param completion Completion handler which is called when the lookup completes. If result.err is
  set then the other values should be ignored.
  */
@@ -189,7 +191,7 @@ typedef NS_ERROR_ENUM(OCSPCacheErrorDomain, OCSPCacheErrorCode) {
     withIssuer:(SecCertificateRef)issuerRef
     andTimeout:(NSTimeInterval)timeout
  modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
- sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+       session:(NSURLSession*__nullable)session
     completion:(void (^)(OCSPCacheLookupResult *result))completion;
 
 /// Blocking lookup
@@ -197,7 +199,7 @@ typedef NS_ERROR_ENUM(OCSPCacheErrorDomain, OCSPCacheErrorCode) {
                       withIssuer:(SecCertificateRef)issuerRef
                       andTimeout:(NSTimeInterval)timeout
                    modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
-                   sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig;
+                         session:(NSURLSession*__nullable)session;
 
 /*!
  Set the cache value for a certificate.

--- a/OCSPCache/Classes/OCSPCache.m
+++ b/OCSPCache/Classes/OCSPCache.m
@@ -127,7 +127,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
 - (void)lookup:(SecTrustRef)secTrustRef
     andTimeout:(NSTimeInterval)timeout
  modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
- sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+       session:(NSURLSession*__nullable)session
     completion:(void (^)(OCSPCacheLookupResult *result))completion {
 
     NSError *e;
@@ -155,7 +155,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
       withIssuer:issuer
       andTimeout:timeout
    modifyOCSPURL:modifyOCSPURL
-   sessionConfig:sessionConfig
+         session:session
       completion:completion];
 }
 
@@ -163,7 +163,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
 - (OCSPCacheLookupResult*)lookup:(SecTrustRef)secTrustRef
                       andTimeout:(NSTimeInterval)timeout
                    modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
-                   sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+                         session:(NSURLSession*__nullable)session
 {
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
 
@@ -172,7 +172,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
     [self lookup:secTrustRef
       andTimeout:timeout
    modifyOCSPURL:modifyOCSPURL
-   sessionConfig:sessionConfig
+         session:session
       completion:^(OCSPCacheLookupResult * _Nonnull result) {
           r = result;
         dispatch_semaphore_signal(sem);
@@ -189,7 +189,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
     withIssuer:(SecCertificateRef)issuerRef
     andTimeout:(NSTimeInterval)timeout
  modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
- sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+       session:(NSURLSession*__nullable)session
     completion:(void (^)(OCSPCacheLookupResult *result))completion {
 
     __weak OCSPCache *weakSelf = self;
@@ -332,7 +332,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
 
         [[OCSPRequestService getSuccessfulOCSPResponse:newURLs
                                        ocspRequestData:ocspReqData
-                                         sessionConfig:sessionConfig
+                                               session:session
                                                  queue:strongSelf->workQueue]
          subscribeNext:^(NSObject * _Nullable x) {
              // OCSPService emits NSError and OCSPResponse
@@ -427,7 +427,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
                       withIssuer:(SecCertificateRef)issuerRef
                       andTimeout:(NSTimeInterval)timeout
                    modifyOCSPURL:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURL
-                   sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+                         session:(NSURLSession*__nullable)session
 {
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
 
@@ -437,7 +437,7 @@ NSErrorDomain _Nonnull const OCSPCacheErrorDomain = @"OCSPCacheErrorDomain";
       withIssuer:issuerRef
       andTimeout:timeout
    modifyOCSPURL:modifyOCSPURL
-   sessionConfig:sessionConfig
+         session:session
       completion:^(OCSPCacheLookupResult * _Nonnull result) {
           r = result;
           dispatch_semaphore_signal(sem);

--- a/OCSPCache/Classes/OCSPRequestService.h
+++ b/OCSPCache/Classes/OCSPRequestService.h
@@ -67,13 +67,14 @@ typedef NS_ERROR_ENUM(OCSPRequestServiceErrorDomain, OCSPRequestServiceErrorCode
  OCSP URLs are attempted in order.
 
  @param ocspURLs OCSP server URLs.
- @param sessionConfig Session configuration with which to perform OCSP requests. This is an opportunity for the caller to
- specify a proxy to be used by the OCSP requests. If nil, `defaultSessionConfiguration` is used.
+ @param session Session with which to perform OCSP requests. This is an opportunity for the caller
+ to specify a proxy to be used by the OCSP requests. If nil, a session with
+ `ephemeralSessionConfiguration` is created and used.
  @param queue Dispatch queue which the network requests should be made on.
  */
 + (RACSignal<NSObject*>*)getSuccessfulOCSPResponse:(NSArray<NSURL*>*)ocspURLs
                                    ocspRequestData:(NSData*)OCSPRequestData
-                                     sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+                                           session:(NSURLSession*__nullable)session
                                              queue:(dispatch_queue_t)queue;
 
 /*!
@@ -84,13 +85,14 @@ typedef NS_ERROR_ENUM(OCSPRequestServiceErrorDomain, OCSPRequestServiceErrorCode
  See: https://tools.ietf.org/html/rfc2560#appendix-A.1.1
 
  @param ocspURL OCSP server URL to make an OCSP request to.
- @param sessionConfig Session configuration with which to perform OCSP requests. This is an opportunity for the caller to
- specify a proxy to be used by the OCSP requests. If nil, `defaultSessionConfiguration` is used.
+ @param session Session with which to perform OCSP requests. This is an opportunity for the caller
+ to specify a proxy to be used by the OCSP requests. If nil, a session with
+ `ephemeralSessionConfiguration` is created and used.
  @param queue Dispatch queue which the network requests should be made on.
  */
 + (RACSignal<NSObject*>*)ocspRequest:(NSURL*)ocspURL
                      ocspRequestData:(NSData*)ocspRequestData
-                       sessionConfig:(NSURLSessionConfiguration*__nullable)sessionConfig
+                             session:(NSURLSession*__nullable)session
                                queue:(dispatch_queue_t)queue;
 
 @end


### PR DESCRIPTION
Motivation:
Previously the caller could specify the NSURLSessionConfiguration
to be used by all sessions. This prevented NSURLSession reuse
which could negatively impact performance.

Modifications:
- Replace NSURLSessionConfiguration with NSURLSession as a
  parameter

Result:
Library consumers can specify per request which NSURLSession will
be used.