### PR TITLE
Fix: set policy on trust

### DIFF
--- a/Example/Tests/Certs/DemoCA/config.cnf
+++ b/Example/Tests/Certs/DemoCA/config.cnf
@@ -176,7 +176,7 @@ authorityInfoAccess = OCSP;URI:http://127.0.0.1:8080
 
 [ bad_ocsp ]
 
-authorityInfoAccess = OCSP;URI:invalid,OCSP;URI:http://example.com:8080
+authorityInfoAccess = OCSP;URI:invalid_ocsp_uri_1,OCSP;URI:invalid_ocsp_uri_2
 
 [ usr_cert ]
 

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -395,7 +395,7 @@
          XCTAssert(r.response == nil);
          XCTAssert(r.err != nil);
          XCTAssert(r.err.domain == OCSPCacheErrorDomain);
-         XCTAssert(r.err.code == OCSPCacheErrorCodeLookupTimedOut);
+         XCTAssert(r.err.code == OCSPCacheErrorCodeNoSuccessfulResponse);
          XCTAssert(r.cached == FALSE);
 
          [expectResult fulfill];

--- a/OCSPCache/Classes/OCSPAuthURLSessionDelegate.m
+++ b/OCSPCache/Classes/OCSPAuthURLSessionDelegate.m
@@ -183,7 +183,7 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
 
     [self evaluateOCSPCacheResult:result
                   evictedResponse:&evictedResponse
-                         trust:trust
+                            trust:trust
                         completed:&completed
                completedWithError:&completedWithError
                 completionHandler:completionHandler];
@@ -205,7 +205,7 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
 
         [self evaluateOCSPCacheResult:result
                       evictedResponse:&evictedResponse
-                             trust:trust
+                                trust:trust
                             completed:&completed
                    completedWithError:&completedWithError
                     completionHandler:completionHandler];
@@ -256,6 +256,8 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
         completedWithError:(BOOL*)completedWithError
          completionHandler:(AuthCompletion)completionHandler {
 
+    SecTrustSetPolicies(trust, policy);
+
     [self evaluateTrust:trust
               completed:completed
      completedWithError:completedWithError
@@ -272,7 +274,7 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
                                                     kSecRevocationRequirePositiveResponse |
                                                     kSecRevocationNetworkAccessDisabled);
     [self evaluateWithPolicy:policy
-                    trust:trust
+                       trust:trust
                    completed:completed
           completedWithError:completedWithError
            completionHandler:completionHandler];
@@ -283,7 +285,7 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
 /// Evaluate response from OCSP cache
 - (void)evaluateOCSPCacheResult:(OCSPCacheLookupResult*)result
                 evictedResponse:(BOOL*)evictedResponse
-                       trust:(SecTrustRef)trust
+                          trust:(SecTrustRef)trust
                       completed:(BOOL*)completed
              completedWithError:(BOOL*)completedWithError
               completionHandler:(AuthCompletion)completionHandler {
@@ -309,10 +311,15 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
         SecTrustResultType trustResultType;
         SecTrustEvaluate(trust, &trustResultType);
 
-        [self evaluateTrust:trust
-                  completed:completed
-         completedWithError:completedWithError
-          completionHandler:completionHandler];
+        SecPolicyRef policy = SecPolicyCreateRevocation(kSecRevocationOCSPMethod |
+                                                        kSecRevocationRequirePositiveResponse |
+                                                        kSecRevocationNetworkAccessDisabled);
+
+        [self evaluateWithPolicy:policy
+                           trust:trust
+                       completed:completed
+              completedWithError:completedWithError
+               completionHandler:completionHandler];
 
         if (!*completed || (*completed && *completedWithError)) {
             [self logWithFormat:@"Evaluate failed with OCSP response from cache"];
@@ -343,7 +350,7 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
                                                     kSecRevocationRequirePositiveResponse);
 
     [self evaluateWithPolicy:policy
-                    trust:trust
+                       trust:trust
                    completed:completed
           completedWithError:completedWithError
            completionHandler:completionHandler];
@@ -363,7 +370,7 @@ modifyOCSPURLOverride:(nullable NSURL * _Nonnull (^)(NSURL * _Nonnull))modifyOCS
     SecPolicyRef policy = SecPolicyCreateRevocation(kSecRevocationCRLMethod);
 
     [self evaluateWithPolicy:policy
-                    trust:trust
+                       trust:trust
                    completed:completed
           completedWithError:completedWithError
            completionHandler:completionHandler];


### PR DESCRIPTION
Fix: set policy on trust

Motivation:
The configured policy for each trust object was not used.
This means that each revocation check in
OCSPAuthURLSessionDelegate would use whatever policy was
previously set on the trust object -- likely the system
defaults. OCSPCache should not be used before this commit.

Modifications:
- Set policy in `evaluateWithPolicy`

Result:
Revocation checks are performed as expected.