### PR TITLE
v0.1.1

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - OCSPCache (0.1.0):
+  - OCSPCache (0.1.1):
     - OpenSSL-Universal (= 1.0.2.17)
     - ReactiveObjC (= 3.1.1)
   - OpenSSL-Universal (1.0.2.17)
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  OCSPCache: abb976c1ac1a9e7203d4ed906eb22f43b49faaac
+  OCSPCache: 3d2186a6b6932cf8f49c17ce5fb8ea4f5f092c82
   OpenSSL-Universal: ff04c2e6befc3f1247ae039e60c93f76345b3b5a
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
 

--- a/Example/Pods/Local Podspecs/OCSPCache.podspec.json
+++ b/Example/Pods/Local Podspecs/OCSPCache.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "OCSPCache",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "summary": "OCSPCache is used for making OCSP requests and caching OCSP responses.",
   "homepage": "https://psiphon3.com",
   "license": {
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/Psiphon-Labs/OCSPCache.git",
-    "tag": "0.1.0"
+    "tag": "0.1.1"
   },
   "source_files": "OCSPCache/Classes/**/*",
   "dependencies": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - OCSPCache (0.1.0):
+  - OCSPCache (0.1.1):
     - OpenSSL-Universal (= 1.0.2.17)
     - ReactiveObjC (= 3.1.1)
   - OpenSSL-Universal (1.0.2.17)
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  OCSPCache: abb976c1ac1a9e7203d4ed906eb22f43b49faaac
+  OCSPCache: 3d2186a6b6932cf8f49c17ce5fb8ea4f5f092c82
   OpenSSL-Universal: ff04c2e6befc3f1247ae039e60c93f76345b3b5a
   ReactiveObjC: 011caa393aa0383245f2dcf9bf02e86b80b36040
 

--- a/OCSPCache.podspec
+++ b/OCSPCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OCSPCache'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'OCSPCache is used for making OCSP requests and caching OCSP responses.'
   s.homepage         = 'https://psiphon3.com'
   s.license          = { :type => 'GNU General Public License v3.0' }

--- a/OCSPCache/Classes/OCSPAuthURLSessionDelegate.h
+++ b/OCSPCache/Classes/OCSPAuthURLSessionDelegate.h
@@ -82,6 +82,7 @@ typedef void (^AuthCompletion)(NSURLSessionAuthChallengeDisposition, NSURLCreden
 /// of its issuer.
 /// @param completionHandler Completion handler from the NSURLSessionDelegate or NSURLSessionTaskDelegate
 /// authentication challenge.
+/// @warning The trust object will be modified and is not safe to access until the call completes.
 - (BOOL)evaluateTrust:(SecTrustRef)trust
     completionHandler:(AuthCompletion)completionHandler;
 
@@ -100,6 +101,7 @@ typedef void (^AuthCompletion)(NSURLSessionAuthChallengeDisposition, NSURLCreden
 /// initialized. This allows independent tasks to mange the NSURLSession used per trust evaluation.
 /// @param completionHandler Completion handler from the NSURLSessionDelegate or NSURLSessionTaskDelegate
 /// authentication challenge.
+/// @warning The trust object will be modified and is not safe to access until the call completes.
 - (BOOL)evaluateTrust:(SecTrustRef)trust
 modifyOCSPURLOverride:(NSURL* (^__nullable)(NSURL *url))modifyOCSPURLOverride
       sessionOverride:(NSURLSession*__nullable)sessionOverride

--- a/OCSPCache/Classes/OCSPCert.m
+++ b/OCSPCache/Classes/OCSPCert.m
@@ -172,6 +172,8 @@ NSErrorDomain _Nonnull const OCSPCertErrorDomain = @"OCSPCertErrorDomain";
                                  userInfo:@{NSLocalizedDescriptionKey:@"Failed to convert issuer "
                                             "cert to OpenSSL X509 "
                                             "object"}];
+        [OCSPCert execCleanupTasks:cleanup];
+        return nil;
     }
 
     [cleanup addObject:^(){

--- a/OCSPCache/Classes/OCSPSecTrust.m
+++ b/OCSPCache/Classes/OCSPSecTrust.m
@@ -36,20 +36,11 @@ void OCSPSecTrustPrintProperties(SecTrustRef trust) {
 // See comment in header
 void OCSPSecTrustAddPolicy(SecTrustRef trust, SecPolicyRef policy) {
     CFArrayRef policies;
-
     SecTrustCopyPolicies(trust, &policies);
 
-    CFIndex policyCount = CFArrayGetCount(policies);
-    CFMutableArrayRef newPolicies = CFArrayCreateMutable(NULL, policyCount+1, NULL);
-
-    CFArrayAppendArray(newPolicies, policies, CFRangeMake(0, policyCount));
-    CFRelease(policies);
-
-    CFArrayAppendValue(newPolicies, policy);
-
-    SecTrustSetPolicies(trust, newPolicies);
-
-    CFRelease(newPolicies);
+    NSArray *newPolicies = (__bridge_transfer NSArray*)policies;
+    newPolicies = [newPolicies arrayByAddingObject:(__bridge_transfer id)policy];
+    SecTrustSetPolicies(trust, (__bridge CFArrayRef)newPolicies);
 }
 
 // See comment in header


### PR DESCRIPTION
Fix crashes on iOS 9.3 and 10.3
- iOS 9.3 and 10.3 have different retain policies
  on SecPolicy objects than iOS 11. We need to
  account for these missing retains or additional
  releases.